### PR TITLE
Add Quantum Phase Estimation tutorial

### DIFF
--- a/docs/tutorials/07_qpe_ground_state.ipynb
+++ b/docs/tutorials/07_qpe_ground_state.ipynb
@@ -1,0 +1,75 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "# Quantum Phase Estimation for H$_2$"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "In deze tutorial laten we zien hoe je de grondtoestand energie van het waterstofmolecuul (`H_2`) kunt bepalen via het Quantum Phase Estimation (QPE) algoritme.\n\nDeze notebook is gebaseerd op de bestaande *Ground state solvers* tutorial en gebruikt de `PySCFDriver` om de Hamiltoniaan van het systeem te verkrijgen."
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## Probleemdefinitie"
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": "from qiskit_nature.units import DistanceUnit\nfrom qiskit_nature.second_q.drivers import PySCFDriver\n\ndriver = PySCFDriver(\n    atom='H 0 0 0; H 0 0 0.735',\n    basis='sto3g',\n    charge=0,\n    spin=0,\n    unit=DistanceUnit.ANGSTROM,\n)\n\nproblem = driver.run()"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## Qubit representatie"
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": "from qiskit_nature.second_q.mappers import JordanWignerMapper\n\nmapper = JordanWignerMapper()\nqubit_op = mapper.map(problem.second_q_ops()[0])"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## Quantum Phase Estimation"
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": "from qiskit_algorithms.phase_estimators import PhaseEstimation, PhaseEstimationScale\nfrom qiskit.primitives import Sampler\n\npe_scale = PhaseEstimationScale(qubit_op)\nunitary = pe_scale.scale(qubit_op)\n\npe = PhaseEstimation(num_evaluation_qubits=5, quantum_instance=Sampler())\nresult = pe.estimate(unitary=unitary, state_preparation=None)\n\nenergy = pe_scale.get_phases(result)[0]\nprint(f'Geschatte grondtoestand energie: {energy:.5f}')"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## Versie informatie"
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": "import tutorial_magics\n\n%qiskit_version_table\n%qiskit_copyright"
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "pygments_lexer": "ipython3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}


### PR DESCRIPTION
## Summary
- add new tutorial showing how to run QPE on H2 using PySCF

## Testing
- `git status --short`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added a new tutorial demonstrating how to compute the ground state energy of H₂ using the Quantum Phase Estimation (QPE) algorithm. The tutorial guides users through problem setup, Hamiltonian mapping, QPE execution, and interpreting results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->